### PR TITLE
seconds should be sec = secondsTotal-minuteTotalToSeconds-HoursTotalT…

### DIFF
--- a/src/Widgets/TimerLabel.vala
+++ b/src/Widgets/TimerLabel.vala
@@ -2,7 +2,7 @@ public class TimerLabel : Gtk.Label {
     public void set_time_in_seconds (uint _seconds, bool compact = true) {
         var hours = (int) (_seconds/3600); // 3600 == 1h
         var minutes = (int) (_seconds - (hours * 3600))/60;
-        var seconds = (int) _seconds - (minutes * 60);
+        var seconds = (int) _seconds - (minutes * 60) - (hours * 3600);
 
         if (compact) {
             label = "%.2i:%.2i".printf (minutes, seconds);


### PR DESCRIPTION
Seconds should be subtracted from `_seconds-(minuteToSeconds+hoursToSeconds)`, otherwise, if the `workingTime>60` the time will be as following:
![image](https://user-images.githubusercontent.com/51538094/147909245-64697b1a-b357-45db-afbc-970e3cc37158.png)

To reproduce the bug, just put 61 minutes, they will be converted to an hour and minute, thus, when you subtract 60 seconds from `_seconds` you will get those 3600.

However, this does not impact the calculation of time, it is just what is printed.

